### PR TITLE
Added functionality to load existing `.duckdb` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ const MyApp = () => {
 }
 ```
 
+
+### Using existing `.duckdb` files
+To use existing `.duckdb` files you need to add these to your `public` folder in react. 
+Configure the `path` in the `DuckDbConfig` to the relative path in the `public` folder. 
+
+For instance if you have the following `public/sample_database.duckdb`, you should configure:
+
+```
+import { initializeDuckDb } from "duckdb-wasm-kit";
+
+const MyApp = () => {
+    useEffect(() => {
+        const config: DuckDBConfig = {
+            query: {
+                path: './sample_database.duckdb'
+            },
+        }
+        initializeDuckDb({ config, debug: true });
+    }, []);
+```
+
+
 ## Performance logging
 
 If you call `initializeDuckDb` with `debug: true`, elapsed times for all queries will be logged to the browser console, which can be useful during development.

--- a/src/init/initializeDuckDb.ts
+++ b/src/init/initializeDuckDb.ts
@@ -49,6 +49,11 @@ const _initializeDuckDb = async (config?: DuckDBConfig): Promise<AsyncDuckDB> =>
   URL.revokeObjectURL(worker_url);
 
   if (config) {
+    if (config.path) {
+      const res = await fetch(config.path);
+      const buffer = await res.arrayBuffer();
+      await db.registerFileBuffer(config.path, new Uint8Array(buffer));
+    }
     await db.open(config);
   }
 


### PR DESCRIPTION
Solves: https://github.com/holdenmatt/duckdb-wasm-kit/issues/3
By preloading an existing `.duckdb` file from the `public` folder in react, you are able to use existing `.duckdb` files.