### PR TITLE
Add support for remote files as well as local files

### DIFF
--- a/src/init/initializeDuckDb.ts
+++ b/src/init/initializeDuckDb.ts
@@ -58,6 +58,8 @@ const _initializeDuckDb = async (config?: DuckDBConfig): Promise<AsyncDuckDB> =>
       }
       await db.registerFileBuffer(config.path, new Uint8Array(buffer));
     }
+    await db.open(config);
+  }
 
   DEBUG && logElapsedTime("DuckDB initialized", start);
   return db;

--- a/src/init/initializeDuckDb.ts
+++ b/src/init/initializeDuckDb.ts
@@ -52,10 +52,12 @@ const _initializeDuckDb = async (config?: DuckDBConfig): Promise<AsyncDuckDB> =>
     if (config.path) {
       const res = await fetch(config.path);
       const buffer = await res.arrayBuffer();
+      const fileNameMatch = config.path.match(/[^/]*$/);
+      if (fileNameMatch) {
+        config.path = fileNameMatch[0];
+      }
       await db.registerFileBuffer(config.path, new Uint8Array(buffer));
     }
-    await db.open(config);
-  }
 
   DEBUG && logElapsedTime("DuckDB initialized", start);
   return db;


### PR DESCRIPTION
- added support for remote files as well as local files, uses purely the filename to load into the buffer and not the full https/http url

E.g. otherwise you are writing a url instead of a file or file path to the virtual wasm file system which will cause errors. Docs do not need to be changed, you can just configure a url, e.g. `https://storage.googleapis.com/some-bucket/some_file.duckdb` or just a file path relative to the `public` folder, e.g. `./some_file.duckdb` as `config.path` property.

solves issue https://github.com/holdenmatt/duckdb-wasm-kit/issues/5